### PR TITLE
Make `font-size-is-readable` configurable

### DIFF
--- a/src/rules/font-size-is-readable/README.md
+++ b/src/rules/font-size-is-readable/README.md
@@ -32,3 +32,21 @@ The following patterns are _not_ considered violations:
   font-size: 1em;
 }
 ```
+
+## Optional secondary options
+
+### `thresholdInPixels: number`
+
+Given:
+
+```
+16
+```
+
+The following pattern is considered a violation:
+
+```css
+.foo {
+  font-size: 15px;
+}
+```

--- a/src/rules/font-size-is-readable/__tests__/index.js
+++ b/src/rules/font-size-is-readable/__tests__/index.js
@@ -43,3 +43,47 @@ testRule({
     },
   ],
 });
+
+testRule({
+  ruleName,
+  config: [true, { thresholdInPixels: 16 }],
+
+  accept: [
+    {
+      code: '.foo { }',
+    },
+    {
+      code: '.foo { font-size: 16px; }',
+    },
+    {
+      code: '.foo { font-size: 12pt; }',
+    },
+    {
+      code: '.bar { FONT-SIZE: 16PX; }',
+    },
+    {
+      code: '.baz { font-size: 1em; }',
+    },
+  ],
+
+  reject: [
+    {
+      code: '.foo { font-size: 15px; }',
+      message: messages.expected('.foo'),
+      line: 1,
+      column: 3,
+    },
+    {
+      code: '.foo { font-size: 3pt; }',
+      message: messages.expected('.foo'),
+      line: 1,
+      column: 3,
+    },
+    {
+      code: '.bar { FONT-SIZE: 8PX; }',
+      message: messages.expected('.bar'),
+      line: 1,
+      column: 3,
+    },
+  ],
+});

--- a/src/rules/font-size-is-readable/index.js
+++ b/src/rules/font-size-is-readable/index.js
@@ -7,22 +7,22 @@ export const messages = utils.ruleMessages(ruleName, {
   expected: (selector) => `Expected a larger font-size in ${selector}`,
 });
 
-const THRESHOLD_IN_PX = 15;
-
 const pxToPt = (v) => 0.75 * v;
 
-const checkInPx = (value) =>
+const checkInPx = (value, THRESHOLD_IN_PX) =>
   value.toLowerCase().endsWith('px') && parseFloat(value) < THRESHOLD_IN_PX;
-const checkInPt = (value) =>
+const checkInPt = (value, THRESHOLD_IN_PX) =>
   value.toLowerCase().endsWith('pt') && parseFloat(value) < pxToPt(THRESHOLD_IN_PX);
 
-export default function (actual) {
+export default function (actual, options) {
   return (root, result) => {
     const validOptions = utils.validateOptions(result, ruleName, { actual });
 
     if (!validOptions || !actual) {
       return;
     }
+
+    const THRESHOLD_IN_PX = (options && options.thresholdInPixels) || 15;
 
     root.walkRules((rule) => {
       let selector = null;
@@ -39,7 +39,7 @@ export default function (actual) {
         return (
           o.type === 'decl' &&
           o.prop.toLowerCase() === 'font-size' &&
-          (checkInPx(o.value) || checkInPt(o.value))
+          (checkInPx(o.value, THRESHOLD_IN_PX) || checkInPt(o.value, THRESHOLD_IN_PX))
         );
       });
 


### PR DESCRIPTION
This pull request adds a `thresholdInPixels` option to be able to change the threshold for `font-size-is-readable` from the default (15) to any other number.


Ref https://github.com/YozhikM/stylelint-a11y/issues/61