### PR TITLE
Remove `menu` from Obsolete Elements

### DIFF
--- a/src/rules/no-obsolete-element/obsoleteElements.js
+++ b/src/rules/no-obsolete-element/obsoleteElements.js
@@ -27,6 +27,5 @@ export const obsoleteElements = new Set([
   'spacer',
   'tt',
   'keygen',
-  'menu',
   'menuitem',
 ]);


### PR DESCRIPTION
The `menu` element was deprecated in HTML 4, but un-deprecated in HTML 5. It's no longer listed in the [Non-conforming features section of the HTML Living Standard](https://html.spec.whatwg.org/multipage/obsolete.html#non-conforming-features) and is no longer marked as deprecated on the [\<menu\>: The Menu element page on MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/menu).

The `menu` is a list element (similar to `ol` and `ul`), so it can only accept `li` children. The `menuitem` element that was intended to be used as a child element of a `menu` is still deprecated, which is why I didn't remove it from the list.