### PR TITLE
fix: import isStandardSyntaxRule from correct module

### DIFF
--- a/src/rules/content-property-no-static-value/index.js
+++ b/src/rules/content-property-no-static-value/index.js
@@ -1,4 +1,4 @@
-import isStandardSyntaxRule from 'stylelint/lib/utils/isStandardSyntaxAtRule.mjs';
+import isStandardSyntaxRule from 'stylelint/lib/utils/isStandardSyntaxRule.mjs';
 import stylelint from 'stylelint';
 const {
   utils: { report, ruleMessages, validateOptions },

--- a/src/rules/font-size-is-readable/index.js
+++ b/src/rules/font-size-is-readable/index.js
@@ -1,4 +1,4 @@
-import isStandardSyntaxRule from 'stylelint/lib/utils/isStandardSyntaxAtRule.mjs';
+import isStandardSyntaxRule from 'stylelint/lib/utils/isStandardSyntaxRule.mjs';
 import stylelint from 'stylelint';
 const {
   utils: { report, ruleMessages, validateOptions },

--- a/src/rules/line-height-is-vertical-rhythmed/index.js
+++ b/src/rules/line-height-is-vertical-rhythmed/index.js
@@ -1,4 +1,4 @@
-import isStandardSyntaxRule from 'stylelint/lib/utils/isStandardSyntaxAtRule.mjs';
+import isStandardSyntaxRule from 'stylelint/lib/utils/isStandardSyntaxRule.mjs';
 import stylelint from 'stylelint';
 const {
   utils: { report, ruleMessages, validateOptions },

--- a/src/rules/media-prefers-color-scheme/index.js
+++ b/src/rules/media-prefers-color-scheme/index.js
@@ -1,6 +1,6 @@
 import isCustomSelector from 'stylelint/lib/utils/isCustomSelector.mjs';
 import isStandardSyntaxAtRule from 'stylelint/lib/utils/isStandardSyntaxAtRule.mjs';
-import isStandardSyntaxRule from 'stylelint/lib/utils/isStandardSyntaxAtRule.mjs';
+import isStandardSyntaxRule from 'stylelint/lib/utils/isStandardSyntaxRule.mjs';
 import isStandardSyntaxSelector from 'stylelint/lib/utils/isStandardSyntaxSelector.mjs';
 
 import stylelint from 'stylelint';

--- a/src/rules/media-prefers-reduced-motion/index.js
+++ b/src/rules/media-prefers-reduced-motion/index.js
@@ -1,6 +1,6 @@
 import isCustomSelector from 'stylelint/lib/utils/isCustomSelector.mjs';
 import isStandardSyntaxAtRule from 'stylelint/lib/utils/isStandardSyntaxAtRule.mjs';
-import isStandardSyntaxRule from 'stylelint/lib/utils/isStandardSyntaxAtRule.mjs';
+import isStandardSyntaxRule from 'stylelint/lib/utils/isStandardSyntaxRule.mjs';
 import isStandardSyntaxSelector from 'stylelint/lib/utils/isStandardSyntaxSelector.mjs';
 import { parse } from 'postcss';
 import stylelint from 'stylelint';

--- a/src/rules/no-display-none/index.js
+++ b/src/rules/no-display-none/index.js
@@ -1,4 +1,4 @@
-import isStandardSyntaxRule from 'stylelint/lib/utils/isStandardSyntaxAtRule.mjs';
+import isStandardSyntaxRule from 'stylelint/lib/utils/isStandardSyntaxRule.mjs';
 import stylelint from 'stylelint';
 const {
   utils: { report, ruleMessages, validateOptions },

--- a/src/rules/no-obsolete-attribute/index.js
+++ b/src/rules/no-obsolete-attribute/index.js
@@ -1,4 +1,4 @@
-import isStandardSyntaxRule from 'stylelint/lib/utils/isStandardSyntaxAtRule.mjs';
+import isStandardSyntaxRule from 'stylelint/lib/utils/isStandardSyntaxRule.mjs';
 import { obsoleteAttributes } from './obsoleteAttributes.js';
 import stylelint from 'stylelint';
 const {

--- a/src/rules/no-obsolete-element/index.js
+++ b/src/rules/no-obsolete-element/index.js
@@ -1,4 +1,4 @@
-import isStandardSyntaxRule from 'stylelint/lib/utils/isStandardSyntaxAtRule.mjs';
+import isStandardSyntaxRule from 'stylelint/lib/utils/isStandardSyntaxRule.mjs';
 import { obsoleteElements } from './obsoleteElements.js';
 import stylelint from 'stylelint';
 const {

--- a/src/rules/no-outline-none/index.js
+++ b/src/rules/no-outline-none/index.js
@@ -1,4 +1,4 @@
-import isStandardSyntaxRule from 'stylelint/lib/utils/isStandardSyntaxAtRule.mjs';
+import isStandardSyntaxRule from 'stylelint/lib/utils/isStandardSyntaxRule.mjs';
 import stylelint from 'stylelint';
 const {
   utils: { report, ruleMessages, validateOptions },

--- a/src/rules/no-spread-text/index.js
+++ b/src/rules/no-spread-text/index.js
@@ -1,4 +1,4 @@
-import isStandardSyntaxRule from 'stylelint/lib/utils/isStandardSyntaxAtRule.mjs';
+import isStandardSyntaxRule from 'stylelint/lib/utils/isStandardSyntaxRule.mjs';
 import stylelint from 'stylelint';
 const {
   utils: { report, ruleMessages, validateOptions },

--- a/src/rules/no-text-align-justify/index.js
+++ b/src/rules/no-text-align-justify/index.js
@@ -1,4 +1,4 @@
-import isStandardSyntaxRule from 'stylelint/lib/utils/isStandardSyntaxAtRule.mjs';
+import isStandardSyntaxRule from 'stylelint/lib/utils/isStandardSyntaxRule.mjs';
 import stylelint from 'stylelint';
 const {
   utils: { report, ruleMessages, validateOptions },

--- a/src/rules/selector-pseudo-class-focus/index.js
+++ b/src/rules/selector-pseudo-class-focus/index.js
@@ -1,4 +1,4 @@
-import isStandardSyntaxRule from 'stylelint/lib/utils/isStandardSyntaxAtRule.mjs';
+import isStandardSyntaxRule from 'stylelint/lib/utils/isStandardSyntaxRule.mjs';
 import stylelint from 'stylelint';
 const {
   utils: { report, ruleMessages, validateOptions },


### PR DESCRIPTION
- issue: #68 

The issue was caused by an incorrect import source for the function `isStandardSyntaxRule `, not by Stylelint.
I tested the corrected code with `stlyelint@16.13.2`, confirming that it passed.