### PR TITLE
Fix readme's stylelint docs link

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ npm i --save-dev stylelint @double-great/stylelint-a11y
 
 Create the `.stylelintrc.json` config file (or open the existing one), add `stylelint-a11y` to the plugins array and the rules you need to the rules list. All rules from stylelint-a11y need to be namespaced with `a11y`.
 
-Please refer to [stylelint docs](https://stylelint.io/user-guide/) for the detailed info on using this linter.
+Please refer to [stylelint docs](https://stylelint.io/#guides) for the detailed info on using this linter.
 
 ## Basic Configuration
 


### PR DESCRIPTION
The docs link's old destination appears to have stopped working in February 2020 when stylelint.io's menu was redesigned.

This updates it to point to the home page's guides section (https://stylelint.io/#guides). It's the closest match for the old destination (https://web.archive.org/web/20191206074839/https://stylelint.io/user-guide/).