### PR TITLE
Revise stylelint docs link

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ npm i --save-dev stylelint @double-great/stylelint-a11y
 
 Create the `.stylelintrc.json` config file (or open the existing one), add `stylelint-a11y` to the plugins array and the rules you need to the rules list. All rules from stylelint-a11y need to be namespaced with `a11y`.
 
-Please refer to [stylelint docs](https://stylelint.io/#guides) for the detailed info on using this linter.
+Please refer to [stylelint docs](https://stylelint.io/user-guide/get-started/) for the detailed info on using this linter.
 
 ## Basic Configuration
 


### PR DESCRIPTION
#131 fixed a broken link to stylelint.io's docs by making it point to the home page's guides section (https://stylelint.io/#guides).

stylelint/stylelint.io#648 was sent shortly afterwards to add an equivalent redirect to stylelint.io itself. But after #131 was merged, stylelint/stylelint.io#648 was revised to point to the user guide's getting started page (https://stylelint.io/user-guide/get-started/).

For consistency, this revises #131's link destination to match stylelint/stylelint.io#648's redirect destination.